### PR TITLE
Remove HTML Tags of calendar item description

### DIFF
--- a/src/notify_scheduled_events/scheduled_event.py
+++ b/src/notify_scheduled_events/scheduled_event.py
@@ -1,3 +1,4 @@
+import re
 import botocore.errorfactory
 import datetime
 from typing import List, Dict
@@ -38,7 +39,7 @@ class ScheduledEvent:
         return {
             'id': self._item_id,
             'title': self._title,
-            'description': self._description,
+            'description': self.description,
             'y': self._start.year,
             'm': self._start.month,
             'd': self._start.day,
@@ -54,6 +55,11 @@ class ScheduledEvent:
     @property
     def notify_needed(self) -> bool:
         return self._notify_needed
+
+    @property
+    def description(self) -> str:
+        p = re.compile(r"<[^>]*?>")
+        return p.sub("", self._description)
 
 
 class ScheduledEventsRepository:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../"))

--- a/tests/notify_scheduled_events/test_scheduled_event.py
+++ b/tests/notify_scheduled_events/test_scheduled_event.py
@@ -1,0 +1,24 @@
+import datetime
+
+from src.notify_scheduled_events.scheduled_event import ScheduledEvent
+
+
+def test_scheduled_event():
+    now = datetime.datetime.now()
+    e = ScheduledEvent(
+        item_id='id',
+        title='title',
+        description='description',
+        start=now,
+        notify_needed=False
+    )
+    assert e.description == 'description'
+
+    e = ScheduledEvent(
+        item_id='id',
+        title='title',
+        description='<a href="page1">description</a>',
+        start=now,
+        notify_needed=False
+    )
+    assert e.description == 'description'


### PR DESCRIPTION
Fixed this:
https://twitter.com/yoppinews/status/1144568828304642048

<img width="622" alt="スクリーンショット 2019-06-29 23 23 13" src="https://user-images.githubusercontent.com/4178716/60385512-f10ded00-9ac4-11e9-9877-4e0536cb551d.png">
